### PR TITLE
Update jenkins-plugins-base-url

### DIFF
--- a/src/steps/jenkins-install.lisp
+++ b/src/steps/jenkins-install.lisp
@@ -132,7 +132,7 @@
   :test #'string=)
 
 (define-constant +jenkins-plugins-base-url+
-    (puri:uri "https://updates.jenkins-ci.org/stable/latest/")
+    (puri:uri "https://updates.jenkins-ci.org/latest/")
   :test #'puri:uri=)
 
 (defun jenkins-plugin-pathname (base-directory name)


### PR DESCRIPTION
fixes #64 

```
./build-generator install-jenkins         \
    -u demo -p demo -e a@b.c              \
    install-test
 0.00 % JENKINS/GET-UPDATE-INFO
100.00 % JENKINS/GET-UPDATE-INFO
  0.00 % INSTALL/CORE
100.00 % INSTALL/CORE
  0.00 % JENKINS/DOWNLOAD-PLUGINS
  0.00 % JENKINS/DOWNLOAD-PLUGINS: extra-columns
  1.22 % JENKINS/DOWNLOAD-PLUGINS: git-client
  ...
 98.78 % JENKINS/DOWNLOAD-PLUGINS: workflow-step-api
100.00 % JENKINS/DOWNLOAD-PLUGINS
```